### PR TITLE
clean projectid version from download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 2.0.0
+
+- download now does not provide projectId and version (if called with version param) - so downloaded structure is more useful to i18next
+- download now appends fileextension .json to the json files
+
+## 1.x.x
+
+- initial version

--- a/download.js
+++ b/download.js
@@ -46,7 +46,12 @@ const download = (opt, cb) => {
     }
 
     obj.forEach((entry) => {
-      const pathToLocalFile = path.join(opt.target, entry.key + '.json');
+      let pathToLocalFile = path.join(opt.target, entry.key + (opt.extension || '.json'));
+      // trim the projectId
+      if (pathToLocalFile.indexOf(opt.projectId + '/') > -1) pathToLocalFile = pathToLocalFile.replace(opt.projectId + '/', '');
+      // trim version if specified
+      if (opt.version) pathToLocalFile = pathToLocalFile.replace(opt.version + '/', '');
+
       mkdirp.sync(path.dirname(pathToLocalFile));
 
       request(entry.url).pipe(fs.createWriteStream(pathToLocalFile));

--- a/download.js
+++ b/download.js
@@ -46,7 +46,7 @@ const download = (opt, cb) => {
     }
 
     obj.forEach((entry) => {
-      let pathToLocalFile = path.join(opt.target, entry.key + (opt.extension || '.json'));
+      var pathToLocalFile = path.join(opt.target, entry.key + (opt.extension || '.json'));
       // trim the projectId
       if (pathToLocalFile.indexOf(opt.projectId + '/') > -1) pathToLocalFile = pathToLocalFile.replace(opt.projectId + '/', '');
       // trim version if specified


### PR DESCRIPTION
- removes projectId from path where translation get stored
- removes version from path if provide on download arguments

=> `locize download --ver latest --target ./locales` writes like expected in i18next

- option to override extension (not exposed on cli for now)