### PR TITLE
Update mkdirp for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "js-yaml": "3.13.1",
     "laravelphp": "1.1.0",
     "lodash.clonedeep": "4.5.0",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^0.5.1",
     "request": "2.88.0",
     "resx": "1.2.0",
     "rimraf": "3.0.1",


### PR DESCRIPTION
**Description**
`mkdirp@0.5.1` has a dependency on `minimist@0.0.8`. According to Github, minimist has a high severity security vulnerability. Updating to a later version of `mkdirp` resolves the issues w/o any breaking changes (according to mkdirp's semantic versioning). Screenshot of Github's automated security message:

<img width="839" alt="Xnip2020-04-09_16-06-44" src="https://user-images.githubusercontent.com/1317291/78948166-58a58f80-7a7c-11ea-807c-5d55f7d64db3.png">
