### PR TITLE
Fix for missing check of `languageFolderPrefix` option (github(#57))

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -409,6 +409,7 @@ const sync = (opt, cb) => {
 
   opt.version = opt.version || 'latest';
   opt.apiPath = opt.apiPath || 'https://api.locize.app';
+  opt.languageFolderPrefix = opt.languageFolderPrefix ?? '';
 
   if (!opt.dry && opt.clean) rimraf.sync(path.join(opt.path, '*'));
   if (!opt.dry) mkdirp.sync(opt.path);

--- a/sync.js
+++ b/sync.js
@@ -409,7 +409,7 @@ const sync = (opt, cb) => {
 
   opt.version = opt.version || 'latest';
   opt.apiPath = opt.apiPath || 'https://api.locize.app';
-  opt.languageFolderPrefix = opt.languageFolderPrefix ?? '';
+  opt.languageFolderPrefix = opt.languageFolderPrefix || '';
 
   if (!opt.dry && opt.clean) rimraf.sync(path.join(opt.path, '*'));
   if (!opt.dry) mkdirp.sync(opt.path);


### PR DESCRIPTION
<!--
Added check for undefined in sync command for `languageFolderPrefix` option.
https://github.com/locize/locize-cli/issues/57
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included (no tests are in project, just lint)
- [x] documentation is changed or added (not needed, internal business logic)