### PR TITLE
fix: allow the usage of environment variables

### DIFF
--- a/bin/locize
+++ b/bin/locize
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('dotenv').config();
 
 const program = require('commander');
 const colors = require('colors');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "commander": "9.5.0",
     "csvjson": "5.1.0",
     "diff": "5.1.0",
+    "dotenv": "16.0.3",
     "flat": "5.0.2",
     "fluent_conv": "3.1.0",
     "gettext-converter": "1.2.3",


### PR DESCRIPTION
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `locize-cli@7.13.2` for the project I'm working on.

In the documentation it states that if environment variables are set, they will be used if no arguments are passed or no locize config.

> Additionally if these environment variables are set:
>
> - LOCIZE_PROJECTID or LOCIZE_PID
> - LOCIZE_API_KEY or LOCIZE_KEY
> - LOCIZE_VERSION or LOCIZE_VER
> - LOCIZE_LANGUAGE or LOCIZE_LANG or LOCIZE_LNG

But they seem to have been missing when running the CLI, I received: `error: missing required argument 'apiKey'`


Here is the diff that solved my problem:

```diff
diff --git a/node_modules/locize-cli/bin/locize b/node_modules/locize-cli/bin/locize
index 7facb5c..04be9fc 100755
--- a/node_modules/locize-cli/bin/locize
+++ b/node_modules/locize-cli/bin/locize
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('dotenv').config();
 
 const program = require('commander');
 const colors = require('colors');
```

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included


#### Related issue : https://github.com/locize/locize-cli/issues/69