### PR TITLE
fix opening of files provided with --config-path

### DIFF
--- a/bin/locize
+++ b/bin/locize
@@ -55,7 +55,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const addPath = options.addPath || config.addPath || addPathUrl;
@@ -113,7 +113,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((namespace, key, value, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const apiKey = options.apiKey || config.apiKey || process.env.LOCIZE_API_KEY || process.env.LOCIZE_KEY;
@@ -172,7 +172,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((namespace, key, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const apiKey = options.apiKey || config.apiKey || process.env.LOCIZE_API_KEY || process.env.LOCIZE_KEY;
@@ -240,7 +240,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const projectId = options.projectId || config.projectId || process.env.LOCIZE_PROJECTID || process.env.LOCIZE_PID;
@@ -309,7 +309,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((namespace, key, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const projectId = options.projectId || config.projectId || process.env.LOCIZE_PROJECTID || process.env.LOCIZE_PID;
@@ -376,7 +376,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const getPath = options.getPath || config.getPath || options.addPath || config.addPath || getPathUrl;
@@ -470,7 +470,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const getPath = options.getPath || config.getPath || options.addPath || config.addPath || getPathUrl;
@@ -542,7 +542,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((fromVersion, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const apiKey = options.apiKey || config.apiKey || process.env.LOCIZE_API_KEY || process.env.LOCIZE_KEY;
@@ -590,7 +590,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const apiKey = options.apiKey || config.apiKey || process.env.LOCIZE_API_KEY || process.env.LOCIZE_KEY;
@@ -637,7 +637,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((namespace, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     const apiKey = options.apiKey || config.apiKey || process.env.LOCIZE_API_KEY || process.env.LOCIZE_KEY;
@@ -685,7 +685,7 @@ program
   .option('-C, --config-path <configPath>', `Specify the path to the optional locize config file (default: ${configInWorkingDirectory} or ${configInHome})`)
   .action((fileOrDirectory, options) => {
     try {
-      config = ini.parse(fs.readFileSync(options.configPath)) || config;
+      config = ini.parse(fs.readFileSync(options.configPath, 'utf-8')) || config;
     } catch (e) {}
 
     fileOrDirectory = fileOrDirectory || '.';


### PR DESCRIPTION
Hello, when using `--config-path` option, `ini.parse` fails to parse the file as `fs.readFileSync` returns a `Buffer` and not a string.

```
/redacted/locize-cli/node_modules/ini/lib/ini.js:72
  const lines = str.split(/[\r\n]+/g)
                    ^

TypeError: str.split is not a function
    at Object.decode (/redacted/locize-cli/node_modules/ini/lib/ini.js:72:21)
    at Command.<anonymous> (/redacted/locize-cli/bin/locize:688:20)
    at Command.listener [as _actionHandler] (/redacted/locize-cli/node_modules/commander/lib/command.js:482:17)
    at /redacted/locize-cli/node_modules/commander/lib/command.js:1283:65
    at Command._chainOrCall (/redacted/locize-cli/node_modules/commander/lib/command.js:1177:12)
    at Command._parseCommand (/redacted/locize-cli/node_modules/commander/lib/command.js:1283:27)
    at /redacted/locize-cli/node_modules/commander/lib/command.js:1081:27
    at Command._chainOrCall (/redacted/locize-cli/node_modules/commander/lib/command.js:1177:12)
    at Command._dispatchSubcommand (/redacted/locize-cli/node_modules/commander/lib/command.js:1077:23)
    at Command._parseCommand (/redacted/locize-cli/node_modules/commander/lib/command.js:1248:19)
```

Note that the above stacktrace is silenced by the try-catch, making it all the more confusing.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added